### PR TITLE
Support notifying remote chare of thread events

### DIFF
--- a/charm4py/__init__.py
+++ b/charm4py/__init__.py
@@ -25,7 +25,7 @@ if os.environ.get('CHARM_NOLOAD', '0') == '0':
     CkExit = charm.exit
     CkAbort = charm.abort
 
-    from .entry_method import when, threaded
+    from .entry_method import when, threaded, threaded_ext
 
     from .chare import Chare, Group, Array, ArrayMap
 

--- a/charm4py/chare.py
+++ b/charm4py/chare.py
@@ -139,13 +139,18 @@ class Chare(object):
         else:
             return charm.lib.getGroupRedNo(proxy.gid)
 
+    def __addThreadEventSubscriber__(self, target, args):
+        self._thread_notify_target = target
+        self._thread_notify_data = args
+
 
 method_restrictions = {
     # reserved methods are those that can't be redefined in user subclass
     'reserved': {'__addLocal__', '__removeLocal__', '__flush_wait_queues__',
                  '__waitEnqueue__', 'wait', 'contribute', 'AtSync',
                  'migrate', '_future_deposit_result',
-                 '_coll_future_deposit_result', '__getRedNo__'},
+                 '_coll_future_deposit_result', '__getRedNo__',
+                 '__addThreadEventSubscriber__'},
 
     # these methods of Chare cannot be entry methods. NOTE that any methods starting
     # and ending with '__' are automatically excluded from being entry methods

--- a/charm4py/entry_method.py
+++ b/charm4py/entry_method.py
@@ -19,6 +19,7 @@ class EntryMethod(object):
         if hasattr(method, '_ck_threaded'):
             self.isThreaded = True  # true if entry method runs in its own thread
             self.run = self.run_threaded
+            self.thread_notify = hasattr(method, '_ck_threaded_notify') and method._ck_threaded_notify
         else:
             self.isThreaded = False
             self.run = self.run_non_threaded
@@ -103,6 +104,14 @@ def when(cond_str):
 def threaded(func):
     func._ck_threaded = True
     return func
+
+
+def threaded_ext(event_notify=False):
+    def _threaded(func):
+        func._ck_threaded = True
+        func._ck_threaded_notify = event_notify
+        return func
+    return _threaded
 
 
 charm = None


### PR DESCRIPTION
Specific threaded entry methods can be tagged for notification
of events (currently pause/resume) to any remote chare.

This is experimental and currently intended for internal use.