### PR TITLE
Call super().__init__() in PoolScheduler __init__

### DIFF
--- a/charm4py/pool.py
+++ b/charm4py/pool.py
@@ -89,6 +89,7 @@ class Job(object):
 class PoolScheduler(Chare):
 
     def __init__(self):
+        super().__init__()
         self.workers = None
         self.idle_workers = set(range(1, charm.numPes()))
         self.num_workers = len(self.idle_workers)


### PR DESCRIPTION
Subclasses of `PoolScheduler` can't work with the `Pool` because a missing attribute `__local_free_head` causes `__addLocal__` to raise an AttributeError. Calling `super().__init__()` in the `PoolScheduler`  `__init__` method seems to fix this since the `Chare` class sets this attribute in its `__init__()`.