### PR TITLE
Fixing cffi autobuild error (convert error to warning)

### DIFF
--- a/charm4py/charmlib/charmlib_cffi_build.py
+++ b/charm4py/charmlib/charmlib_cffi_build.py
@@ -100,7 +100,7 @@ ffibuilder.set_source("charm4py.charmlib._charmlib_cffi",
     libraries=['charm'],
     include_dirs=['charm_src/charm/include'],
     library_dirs=['charm4py/.libs'],
-    extra_compile_args=['-g0', '-O3'],
+    extra_compile_args=['-g0', '-O3', '-Wno-error=incompatible-function-pointer-types'],
     extra_link_args=extra_link_args)
 
 ffibuilder.cdef("""

--- a/charm4py/charmlib/charmlib_cffi_build.py
+++ b/charm4py/charmlib/charmlib_cffi_build.py
@@ -6,10 +6,10 @@ ffibuilder = FFI()
 
 if platform.system() == 'Darwin':
     extra_link_args=["-Wl,-rpath,@loader_path/../.libs"]
-    extra_compile_args=['-g0', '-O3', '-Wno-error=incompatible-function-pointer-types']
+    extra_compile_args=['-Wno-error=incompatible-function-pointer-types']
 else:
     extra_link_args=["-Wl,-rpath,$ORIGIN/../.libs"]
-    extra_compile_args=['-g0', '-O3']
+    extra_compile_args=[]
 
 
 ffibuilder.set_source("charm4py.charmlib._charmlib_cffi",

--- a/charm4py/charmlib/charmlib_cffi_build.py
+++ b/charm4py/charmlib/charmlib_cffi_build.py
@@ -6,8 +6,10 @@ ffibuilder = FFI()
 
 if platform.system() == 'Darwin':
     extra_link_args=["-Wl,-rpath,@loader_path/../.libs"]
+    extra_compile_args=['-g0', '-O3', '-Wno-error=incompatible-function-pointer-types']
 else:
     extra_link_args=["-Wl,-rpath,$ORIGIN/../.libs"]
+    extra_compile_args=['-g0', '-O3']
 
 
 ffibuilder.set_source("charm4py.charmlib._charmlib_cffi",
@@ -100,7 +102,7 @@ ffibuilder.set_source("charm4py.charmlib._charmlib_cffi",
     libraries=['charm'],
     include_dirs=['charm_src/charm/include'],
     library_dirs=['charm4py/.libs'],
-    extra_compile_args=['-g0', '-O3', '-Wno-error=incompatible-function-pointer-types'],
+    extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args)
 
 ffibuilder.cdef("""

--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,7 @@ else:
                               include_dirs=['charm_src/charm/include'] + my_include_dirs,
                               library_dirs=[os.path.join(os.getcwd(), 'charm4py', '.libs')],
                               libraries=["charm"],
-                              extra_compile_args=['-g0', '-O3'],
+                              extra_compile_args=[],
                               extra_link_args=extra_link_args,
                               ), compile_time_env={'HAVE_NUMPY': haveNumpy}))
 
@@ -352,7 +352,7 @@ else:
                               include_dirs=['charm_src/charm/include'] + my_include_dirs,
                               library_dirs=[os.path.join(os.getcwd(), 'charm4py', '.libs')],
                               libraries=["charm"],
-                              extra_compile_args=['-g0', '-O3'],
+                              extra_compile_args=[],
                               extra_link_args=cobject_extra_args,
                               ), compile_time_env={'HAVE_NUMPY': haveNumpy}))
     else:


### PR DESCRIPTION
I'm not sure exactly what internal update caused the autobuild to break on macos14 between nightly build 718 and 719 (speculating that its the xcode update from 15.0 to 15.4, but I have not investigated this), but it causes clang to treat `-Wincompatible-function-pointer-types` as an error by default. 

This compiler flag forces clang to treat this error as a warning, which matches the previous behavior, as seen in nightly build 718.

I can replicate this error (and fix) locally on my mac with xcode/15.4 (must force the cffi build via `export CHARM4PY_BUILD_CFFI=1`).
