### PR TITLE
get rid of old libmpi fix

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -117,7 +117,7 @@ class Charm(object):
         self.options.remote_exec = False
         self.options.interactive = Options()
         self.options.interactive.verbose = 1
-        self.options.interactive.broadcast_imports = True    
+        self.options.interactive.broadcast_imports = True
         self.lib = load_charm_library(self)
         self.ReducerType = self.lib.ReducerType
         self.CkContributeToChare = self.lib.CkContributeToChare


### PR DESCRIPTION
In charm.py, there was old code that used to explicitly require loading the libmpi.so DLL when running a charm4py program. it is not needed anymore, because openmpi fixed this here: (https://github.com/open-mpi/ompi/issues/3705). So I commented this part out, which prevented charm4py from running when using mpirun. Without this, mpirun works for charm4py programs.