### PR TITLE
Sanity check examples to be packaged with binary distribution

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,6 +28,17 @@ This will install the latest stable release of Charm4Py, using the default under
 use a specific Charm++ build, you can install and build Charm4Py from source. Note that the source distribution
 is available via "pip install", but the standard from source build process is via "git clone", as outlined below.
 
+Charm4Py provides a small number of examples with the binary distribution that can be used as a sanity check to verify basic functionality of the installation.
+Examples can be run via the following command line tool installed with Charm4Py::
+
+    $ charm4py_test [test_name]
+
+Currently, Charm4Py binaries are distributed with the following tests (to be substituted for [test_name]):
+
+- 'group_hello' - A simple hello world example wherein all members of a group print a message.
+- 'array_hello' - A simple hello world example wherein all elements of an array print a message one at a time, passing a message to the next element.
+- 'simple_ray' - A simple example of a Ray application.
+
 Installing Charm4Py from source
 ------------------------------------------------------------
 
@@ -66,7 +77,12 @@ array_hello.py, which can be run as follows::
     $ cd examples/hello
     $ python -m charmrun.start +p2 array_hello.py
 
-Choosing your target architecture when building from source
+
+To run the full Charm4py test suite after building from source, run the following command from the repository root::
+
+    $ python auto_test.py
+
+Choosing your target architecture
 ------------------------------------------------------------
 
 When building from source, as described above, you must chose the appropriate target architecture.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -31,13 +31,15 @@ is available via "pip install", but the standard from source build process is vi
 Charm4Py provides a small number of examples with the binary distribution that can be used as a sanity check to verify basic functionality of the installation.
 Examples can be run via the following command line tool installed with Charm4Py::
 
-    $ charm4py_test [test_name]
+    $ charm4py_test [example]
 
-Currently, Charm4Py binaries are distributed with the following tests (to be substituted for [test_name]):
+Currently, Charm4Py binaries are distributed with the following examples:
 
 - 'group_hello' - A simple hello world example wherein all members of a group print a message.
 - 'array_hello' - A simple hello world example wherein all elements of an array print a message one at a time, passing a message to the next element.
 - 'simple_ray' - A simple example of a Ray application.
+
+To run a comprehensive set of tests, install Charm4py from source.
 
 Installing Charm4Py from source
 ------------------------------------------------------------

--- a/minitest/array_hello.py
+++ b/minitest/array_hello.py
@@ -1,0 +1,51 @@
+from charm4py import charm, Chare, Array
+
+# This example creates a multi-dimensional distributed chare array, and has
+# elements of the array pass a message consecutively from one to the next in
+# row-major order
+
+
+class Hello(Chare):
+
+    def __init__(self, array_dims):
+        self.array_dims = array_dims
+
+    def sayHi(self, hello_num):
+        print('Hi[' + str(hello_num) + '] from element', self.thisIndex, 'on PE', charm.myPe())
+        lastIdx = tuple([size-1 for size in self.array_dims])
+        if self.thisIndex == lastIdx:
+            # this is the last index, we are done
+            print('All done')
+            exit()
+        else:
+            # send a hello message to the next element (in row-major order)
+            nextIndex = list(self.thisIndex)
+            num_dims = len(self.array_dims)
+            for i in range(num_dims-1, -1, -1):
+                nextIndex[i] = (nextIndex[i] + 1) % self.array_dims[i]
+                if nextIndex[i] != 0:
+                    break
+            return self.thisProxy[nextIndex].sayHi(hello_num + 1)
+
+
+def main(args):
+    print('\nUsage: array_hello.py [dim1_size dim2_size ...]')
+    array_dims = (2, 2, 2)  # default: create a 2 x 2 x 2 chare array
+    if len(args) > 1:
+        array_dims = tuple([int(x) for x in args[1:]])
+
+    num_elems = 1
+    for size in array_dims:
+        num_elems *= size
+    print('Running Hello on', charm.numPes(), 'processors for', num_elems,
+          'elements, array dimensions are', array_dims)
+
+    # create a chare array of Hello chares, passing the array dimensions to
+    # each element's constructor
+    array_proxy = Array(Hello, array_dims, args=[array_dims])
+    firstIdx = (0,) * len(array_dims)
+    # send hello message to the first element
+    array_proxy[firstIdx].sayHi(17)
+
+
+charm.start(main)

--- a/minitest/group_hello.py
+++ b/minitest/group_hello.py
@@ -1,0 +1,18 @@
+from charm4py import Chare, Group, charm
+
+
+class Hello(Chare):
+
+    def SayHi(self):
+        print('Hello World from element', self.thisIndex)
+
+
+def main(args):
+    # create Group of Hello objects (there will be one object on each core)
+    hellos = Group(Hello)
+    # call method 'SayHi' of all group members, wait for method to be invoked on all
+    hellos.SayHi(awaitable=True).get()
+    exit()
+
+
+charm.start(main)

--- a/minitest/mini_test.py
+++ b/minitest/mini_test.py
@@ -1,49 +1,79 @@
 import time
 import subprocess
 import sys
+
 if sys.version_info[0] < 3:
     print("mini_test requires Python 3")
     exit(1)
+    
 import os
 import shutil
 from collections import defaultdict
 import json
+import argparse
 
+def parse_args():
+    # Create the parser
+    parser = argparse.ArgumentParser(
+        description="Run a minimal charm4py example."
+    )
+    
+    # Add the required positional argument
+    parser.add_argument(
+        'example',
+        type=str,
+        choices=['group_hello', 'array_hello', 'simple_ray'],
+        help='The name of the example to run (required). Current supported example group_hello, array_hello, simple_ray.'
+    )
+    
+    # Add the optional argument
+    parser.add_argument(
+        '-i', '--interface',
+        type=str,
+        help='Specify the libcharm interface to use (optional). Current supported interfaces: ctypes, cython, cffi.'
+    )
+    
+    parser.add_argument(
+        '-n', '--num_processes',
+        type=int,
+        help='Specify the number of processes to use (optional). Default is 4.'
+    )
+
+    # Parse the arguments
+    return parser.parse_args()
+    
 def mini_test():
-    if len(sys.argv) != 2:
-        print("Usage: python mini_test.py [test_name: group_hello, array_hello, simple_ray]")
-        exit(1)
-
+    args = parse_args()
+    
     script_dir = os.path.dirname(os.path.realpath(__file__))
 
-    test_name = sys.argv[1]
-    test_file = script_dir + '/' + test_name + '.py'
+    example = args.example
+    example_file = script_dir + '/' + example + '.py'
 
-    if not os.path.exists(test_file):
-        print("Test " + test_file + " not found")
+    if not os.path.exists(example_file):
+        print("Example" + example_file + " not found")
         exit(1)
-        
-    # TODO: add arguments for libcharm_interface
+    
 
-
-
-    commonArgs = ['++local']
-    default_num_processes = int(os.environ.get('CHARM4PY_TEST_NUM_PROCESSES', 4))
-
-    num_processes = default_num_processes
-    python_executable = sys.executable
     TIMEOUT = 120  # timeout for each test (in seconds)
-
-            
-    cmd = [python_executable]
-    cmd += ["-m", "charmrun.start"]
-
-    cmd += commonArgs
+ 
+    cmd = ["charmrun"]
+    cmd += ['++local']
+    
+    num_processes = 4
+    if args.num_processes:
+        num_processes = args.num_processes
+        
     cmd += ['+p' + str(num_processes)]
-    # TODO: optional interface setting
-    # cmd += ['+libcharm_interface', interface]
-    cmd += [test_file]
-    print('Test command is ' + ' '.join(cmd))
+    
+    
+   
+    cmd += [example_file]
+    
+    if args.interface:
+        cmd += ['+libcharm_interface', args.interface]
+        
+    print('Command is: ' + ' '.join(cmd))
     startTime = time.time()
     stdin = None
 
@@ -51,16 +81,16 @@ def mini_test():
     try:
         rc = p.wait(TIMEOUT)
     except subprocess.TimeoutExpired:
-        print("Timeout (" + str(TIMEOUT) + " secs) expired when running " + test_name + ", Killing process")
+        print("Timeout (" + str(TIMEOUT) + " secs) expired when running " + example + ", Killing process")
         p.kill()
         rc = -1
     if rc != 0:
-        print("ERROR running test " + test_name + " with " + python_executable)
+        print("ERROR running example " + example)
         exit(1)
     else:
         elapsed = round(time.time() - startTime, 3)
         
-        print("\n\n--------------------- TEST RAN (in " + str(elapsed) + " secs) ---------------------\n\n")
+        print("\n\n--------------------- EXAMPLE RAN (in " + str(elapsed) + " secs) ---------------------\n\n")
     
 if __name__ == "__main__":
     mini_test()

--- a/minitest/mini_test.py
+++ b/minitest/mini_test.py
@@ -1,0 +1,66 @@
+import time
+import subprocess
+import sys
+if sys.version_info[0] < 3:
+    print("mini_test requires Python 3")
+    exit(1)
+import os
+import shutil
+from collections import defaultdict
+import json
+
+def mini_test():
+    if len(sys.argv) != 2:
+        print("Usage: python mini_test.py [test_name: group_hello, array_hello, simple_ray]")
+        exit(1)
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+
+    test_name = sys.argv[1]
+    test_file = script_dir + '/' + test_name + '.py'
+
+    if not os.path.exists(test_file):
+        print("Test " + test_file + " not found")
+        exit(1)
+        
+    # TODO: add arguments for libcharm_interface
+
+
+
+    commonArgs = ['++local']
+    default_num_processes = int(os.environ.get('CHARM4PY_TEST_NUM_PROCESSES', 4))
+
+    num_processes = default_num_processes
+    python_executable = sys.executable
+    TIMEOUT = 120  # timeout for each test (in seconds)
+
+            
+    cmd = [python_executable]
+    cmd += ["-m", "charmrun.start"]
+
+    cmd += commonArgs
+    cmd += ['+p' + str(num_processes)]
+    # TODO: optional interface setting
+    # cmd += ['+libcharm_interface', interface]
+    cmd += [test_file]
+    print('Test command is ' + ' '.join(cmd))
+    startTime = time.time()
+    stdin = None
+
+    p = subprocess.Popen(cmd, stdin=stdin)
+    try:
+        rc = p.wait(TIMEOUT)
+    except subprocess.TimeoutExpired:
+        print("Timeout (" + str(TIMEOUT) + " secs) expired when running " + test_name + ", Killing process")
+        p.kill()
+        rc = -1
+    if rc != 0:
+        print("ERROR running test " + test_name + " with " + python_executable)
+        exit(1)
+    else:
+        elapsed = round(time.time() - startTime, 3)
+        
+        print("\n\n--------------------- TEST RAN (in " + str(elapsed) + " secs) ---------------------\n\n")
+    
+if __name__ == "__main__":
+    mini_test()

--- a/minitest/simple_ray.py
+++ b/minitest/simple_ray.py
@@ -1,0 +1,50 @@
+from charm4py import charm, coro, Chare, Array, ray
+from time import sleep
+import numpy as np
+
+
+@ray.remote
+def add_task(a, b):
+    sleep(2)
+    if a != -1:
+        res = add_task.remote(-1, a)
+        res = ray.get(res)
+    print("Add task", a, b)
+    return a + b
+
+@ray.remote
+class Compute(object):
+    def __init__(self, arg):
+        print('Hello from MyChare instance in processor', charm.myPe(), 'index', self.thisIndex, arg)
+
+    def add(self, a, b):
+        sleep(2)
+        print("Add actor method", a, b)
+        return a + b
+
+
+def main(args):
+    ray.init()
+    # create 3 instances of MyChare, distributed among cores by the runtime
+    arr = [Compute.remote(i) for i in range(4)]
+    
+    obj1 = np.arange(100)
+    obj2 = np.arange(100)
+    a = ray.put(obj1)
+    b = ray.put(obj2)
+    c = arr[0].add.remote(1, 2) # fut id 0
+    d = arr[1].add.remote(3, c) # fut id 1
+    e = arr[2].add.remote(2, d)
+    f = arr[3].add.remote(c, 4)
+    g = arr[3].add.remote(a, b)
+    h = add_task.remote(e, f)
+
+    not_ready = [c, d, e, f, g, h]
+    while len(not_ready) > 0:
+        ready, not_ready = ray.wait(not_ready)
+        print("Fetched value: ", ray.get(ready))
+
+    exit()
+
+
+charm.start(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,4 @@ Repository = "https://github.com/charmplusplus/charm4py"
 
 [project.scripts]
 charmrun = 'charmrun.start:start'
+charm4py_test = 'minitest.mini_test:mini_test'


### PR DESCRIPTION
I'm adding a set of examples that can be run via a command line interface after installing Charm4py from a binary distribution. These examples were copied from the examples folder.

**TODO:**
- [ ] I'm unsure if this is the best directory structure. Putting minitest inside of the `charm4py` module causes the following warning to be printed after any minitest: `Program is exiting but charm was not started: charm.start() was not called or error happened before start` As is, minitest cannot be placed inside `tests` because tests is not a module.
- [ ] Also, I'm not sure about the naming of various things (minitest, charm4py_test, etc). Open to feedback!
- [ ] Should more options be provided at CLI? Should `++local` be forced?