### PR TITLE
Check for pe num in pool examples and point to documentation

### DIFF
--- a/examples/pool/pool_fibonacci.py
+++ b/examples/pool/pool_fibonacci.py
@@ -9,6 +9,9 @@ def fib(n):
     return sum(charm.pool.map(fib, [n-1, n-2]))
 
 def main(args):
+    if(charm.numPes()==1):
+        print("Error: Run with more than one PE (exiting). For documentation on using pools, see: https://charm4py.readthedocs.io/en/latest/pool.html")
+        exit()
     print('fibonacci(13)=', fib(13))
     exit()
 

--- a/examples/pool/pool_simple.py
+++ b/examples/pool/pool_simple.py
@@ -9,6 +9,9 @@ def twice(x):
 
 def main(args):
     ray.init()
+    if(charm.numPes()==1):
+        print("Error: Run with more than one PE (exiting). For documentation on using pools, see: https://charm4py.readthedocs.io/en/latest/pool.html")
+        exit()
     results = charm.pool.map_async(square, [4], chunksize=1, multi_future=True)
     results_twice = charm.pool.map_async(twice, results, chunksize=1, multi_future=True)
 

--- a/examples/pool/pool_simple.py
+++ b/examples/pool/pool_simple.py
@@ -13,7 +13,10 @@ def main(args):
         print("Error: Run with more than one PE (exiting). For documentation on using pools, see: https://charm4py.readthedocs.io/en/latest/pool.html")
         exit()
     results = charm.pool.map_async(square, [4], chunksize=1, multi_future=True)
-    results_twice = charm.pool.map_async(twice, results, chunksize=1, multi_future=True)
+    real_results = []
+    for item in results:
+        real_results.append(item.get())
+    results_twice = charm.pool.map_async(twice, real_results, chunksize=1, multi_future=True, is_ray=True)
 
     for x in results_twice:
         print(x.get())


### PR DESCRIPTION
Resolve #263. For the pool examples, this checks if the program is launched with only one PE, and points to the pool documentation if it is (then exits). Also fixes the pool_simple.py example to work (right now, task pools on lists of futures don't work).