### PR TITLE
get mac builds to use cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -297,7 +297,7 @@ class _renameInstalled(_install_lib):
                 direc = os.path.dirname(file)
                 install_name_command = "install_name_tool -change lib/libcharm.dylib "
                 install_name_command += direc
-                install_name_command += "/.libs/libcharm.dylib "
+                install_name_command += "/../.libs/libcharm.dylib "
                 install_name_command += direc
                 install_name_command += "/charmlib_cython.*.so"
                 log.info(install_name_command)


### PR DESCRIPTION
I needed to make a small change in the setup.py file to get the cython shared object file to correctly point to the libcharm dynamic library, so that cython (not ctypes) would be used on macs.