### PR TITLE
Testsuite bugfix: ubuntu 24.04 drops python 3.7

### DIFF
--- a/.github/workflows/charm4py.yml
+++ b/.github/workflows/charm4py.yml
@@ -13,11 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7", "3.8", "3.12"]
         # macos-13 is x86_64, macos-14 is arm64
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-14]
         exclude:
-          - os: macos-14  # Python 3.7 does not exist for macos-14
+          - os: macos-14 # Python 3.7 does not exist for macos-14
+            python-version: "3.7"
+          - os: ubuntu-latest # Ubuntu 24.04 drops python 3.7 support
             python-version: "3.7"
       fail-fast: false
 

--- a/.github/workflows/charm4py.yml
+++ b/.github/workflows/charm4py.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.12"]
+        python-version: ["3.7", "3.9", "3.12"]
         # macos-13 is x86_64, macos-14 is arm64
         os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-14]
         exclude:
           - os: macos-14 # Python 3.7 does not exist for macos-14
             python-version: "3.7"
-          - os: ubuntu-latest # Ubuntu 24.04 drops python 3.7 support
+          - os: ubuntu-latest # Ubuntu 24.04 drops python 3.7 and 3.8 support
             python-version: "3.7"
       fail-fast: false
 

--- a/.github/workflows/charm4py.yml
+++ b/.github/workflows/charm4py.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.12"]
+        python-version: ["3.7", "3.9", "3.12", "3.13"]
         # macos-13 is x86_64, macos-14 is arm64
         os: [ubuntu-22.04, ubuntu-latest, macos-13, macos-14]
         exclude:


### PR DESCRIPTION
Test ci uses "ubuntu-latest" which was recently bumped from 22.04 to 24.04. Ubuntu24.04 no longer supports Python3.7. This PR aims to fix the CI test failure. More details on ubuntu/python support listed [here](https://github.com/actions/runner-images/issues/10636).

Noting that python3.7 hit EOL in 2023, it may be time to just remove python3.7 support instead of making fixes like this. Thoughts?